### PR TITLE
Updated the version number to 0.0.11

### DIFF
--- a/lib/redmine_issues_tree/version.rb
+++ b/lib/redmine_issues_tree/version.rb
@@ -1,3 +1,3 @@
 module RedmineIssuesTree
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end


### PR DESCRIPTION
The plugin page (https://www.redmine.org/plugins/redmine_issues_tree) says it's 0.0.11. So when you download/install the package Redmine says it's .10 and propose to update the plugin.
At least now, it will not propose an update.