### PR TITLE
enable default treeview on top Issues page

### DIFF
--- a/app/views/settings/_redmine_issues_tree.html.haml
+++ b/app/views/settings/_redmine_issues_tree.html.haml
@@ -1,5 +1,10 @@
 %p
   %label
-    = l(:'issues_tree.settings.default_redirect_to_tree_view')
-  = hidden_field_tag 'settings[default_redirect_to_tree_view]', false
-  = check_box_tag 'settings[default_redirect_to_tree_view]', true, @settings['default_redirect_to_tree_view'] == 'true'
+    = l(:'issues_tree.settings.default_redirect_to_issues_tree_view')
+  = hidden_field_tag 'settings[default_redirect_to_issues_tree_view]', false
+  = check_box_tag 'settings[default_redirect_to_issues_tree_view]', true, @settings['default_redirect_to_issues_tree_view'] == 'true'
+%p
+  %label
+    = l(:'issues_tree.settings.default_redirect_to_project_issues_tree_view')
+  = hidden_field_tag 'settings[default_redirect_to_project_issues_tree_view]', false
+  = check_box_tag 'settings[default_redirect_to_project_issues_tree_view]', true, @settings['default_redirect_to_project_issues_tree_view'] == 'true'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -7,5 +7,7 @@ cs:
     errors:
       unable_to_group_in_tree_view: Nelze seskupit do stromového pohledu
     settings:
-      default_redirect_to_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for issues (this can be very slowly in case of project with >1000 issues)"
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: "[TRANSLATE ME] Set a tree view as default for project issues (this can be very slowly in case of project with >1000 issues)"
+
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,4 +7,6 @@ de:
     errors:
       unable_to_group_in_tree_view: Es ist keine Gruppierung in der Baumansicht möglich
     settings:
-      default_redirect_to_tree_view: Baumansicht als Standard für Tickets verwenden (bei Projekten mit >1000 Tickets kann die Anzeige der Tickets sehr lange dauern)
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: "[TRANSLATE ME] Set a tree view as default for project issues (this can be very slowly in case of project with >1000 issues)"
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,4 +7,5 @@ en:
     errors:
       unable_to_group_in_tree_view: Unable to group in tree view
     settings:
-      default_redirect_to_tree_view: Set a tree view as a default index page for issues (this can be very slowly in case of project with >1000 issues)
+      default_redirect_to_issues_tree_view: Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)
+      default_redirect_to_project_issues_tree_view: Set a tree view as default for project issues (this can be very slowly in case of project with >1000 issues)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,4 +7,6 @@ ja:
     errors:
       unable_to_group_in_tree_view: ツリー表示でグループ化できませんでした
     settings:
-      default_redirect_to_tree_view: チケットの初期表示をツリー表示に設定する (これは1000より多くのチケットがある場合、非常に遅くなります)
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: チケットの初期表示をツリー表示に設定する (これは1000より多くのチケットがある場合、非常に遅くなります)
+

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,4 +7,7 @@ pt-BR:
     errors:
       unable_to_group_in_tree_view: Não é possível agrupar a visualização
     settings:
-      default_redirect_to_tree_view: Defina uma visão em árvore como uma página de índice padrão para problemas (isso pode ser muito lento em caso de projeto com mais de 1000 problemas)
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: Defina uma visão em árvore como uma página de índice padrão para problemas (isso pode ser muito lento em caso de projeto com mais de 1000 problemas)
+
+

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -7,4 +7,6 @@ pt:
     errors:
       unable_to_group_in_tree_view: Não é possível agrupar a visualização
     settings:
-      default_redirect_to_tree_view: Defina uma visão em árvore como uma página de índice padrão para problemas (isso pode ser muito lento em caso de projeto com mais de 1000 problemas)
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: Defina uma visão em árvore como uma página de índice padrão para problemas (isso pode ser muito lento em caso de projeto com mais de 1000 problemas)
+

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -7,4 +7,6 @@ ru:
     errors:
       unable_to_group_in_tree_view: Невозможно группировать записи при древовидном отображении
     settings:
-      default_redirect_to_tree_view: По-умолчанию отображать задачи в древовидной форме (может сильно тормозить в проектах с >1000 задач)
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: По-умолчанию отображать задачи в древовидной форме (может сильно тормозить в проектах с >1000 задач)
+

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -7,4 +7,6 @@ tr:
     errors:
       unable_to_group_in_tree_view: Ağaç görünümü için gruplandırma yapılamıyor
     settings:
-      default_redirect_to_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for issues (this can be very slowly in case of project with >1000 issues)"
+      default_redirect_to_issues_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for all issues (enable this could be very slowly in case of with many issues)"
+      default_redirect_to_project_issues_tree_view: "[TRANSLATE ME] Set a tree view as default for project issues (this can be very slowly in case of project with >1000 issues)"
+

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -8,4 +8,5 @@ zh-TW:
     errors:
       unable_to_group_in_tree_view: 無法以樹狀視圖分組
     settings:
-      default_redirect_to_tree_view: "[TRANSLATE ME] Set a tree view as a default index page for issues (this can be very slowly in case of project with >1000 issues)"
+      default_redirect_to_issues_tree_view: 將樹狀視圖設為全部問題的默認顯示頁面（可能會導致顯示速度非常非常慢，慎用！！）
+      default_redirect_to_project_issues_tree_view: 將樹狀視圖設為項目問題的默認顯示頁面（若項目包含超過1000+以上的問題，顯示速度將會非常非常慢，慎用！！）

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -8,4 +8,5 @@ zh:
     errors:
       unable_to_group_in_tree_view: 无法以树状视图分组
     settings:
-      default_redirect_to_tree_view: 将树状视图设为问题的默认显示页面（若项目包含超过1，000+以上的问题，显示速度将会非常非常慢，慎用！！）
+      default_redirect_to_issues_tree_view: 将树状视图设为全部问题的默认显示页面（可能会导致显示速度非常非常慢，慎用！！）
+      default_redirect_to_project_issues_tree_view: 将树状视图设为项目问题的默认显示页面（若项目包含超过1，000+以上的问题，显示速度将会非常非常慢，慎用！！）

--- a/lib/redmine_issues_tree/issues_controller_patch.rb
+++ b/lib/redmine_issues_tree/issues_controller_patch.rb
@@ -9,12 +9,16 @@ module RedmineIssuesTree::IssuesControllerPatch
     skip_issues_tree_redirect = params.delete(:skip_issues_tree_redirect)
 
     # @note: do not change behaviour of issues#index for all projects
-    if Setting.plugin_redmine_issues_tree.with_indifferent_access[:default_redirect_to_tree_view] == 'true' && params[:project_id].present?
-      # @note: add additional parameter into all links on issues#index looks not so good as parsing a referer
-      if skip_issues_tree_redirect == 'true' || URI(request.referer).path == project_issues_path
-        index_without_redmine_issues_tree
+    if Setting.plugin_redmine_issues_tree.with_indifferent_access[:default_redirect_to_tree_view] == 'true' 
+      if params[:project_id].present?
+        # @note: add additional parameter into all links on issues#index looks not so good as parsing a referer
+        if skip_issues_tree_redirect == 'true' || URI(request.referer).path == project_issues_path
+          index_without_redmine_issues_tree
+        else
+          redirect_to tree_index_project_issues_trees_path(request.query_parameters)
+        end
       else
-        redirect_to tree_index_project_issues_trees_path(request.query_parameters)
+        redirect_to tree_index_issues_trees_path(request.query_parameters)
       end
     else
       index_without_redmine_issues_tree

--- a/lib/redmine_issues_tree/issues_controller_patch.rb
+++ b/lib/redmine_issues_tree/issues_controller_patch.rb
@@ -7,10 +7,9 @@ module RedmineIssuesTree::IssuesControllerPatch
 
   def index_with_redmine_issues_tree
     skip_issues_tree_redirect = params.delete(:skip_issues_tree_redirect)
-
     # @note: do not change behaviour of issues#index for all projects
-    if Setting.plugin_redmine_issues_tree.with_indifferent_access[:default_redirect_to_tree_view] == 'true' 
-      if params[:project_id].present?
+    if  params[:project_id].present?
+      if Setting.plugin_redmine_issues_tree.with_indifferent_access[:default_redirect_to_project_issues_tree_view] == 'true'
         # @note: add additional parameter into all links on issues#index looks not so good as parsing a referer
         if skip_issues_tree_redirect == 'true' || URI(request.referer).path == project_issues_path
           index_without_redmine_issues_tree
@@ -18,10 +17,16 @@ module RedmineIssuesTree::IssuesControllerPatch
           redirect_to tree_index_project_issues_trees_path(request.query_parameters)
         end
       else
-        redirect_to tree_index_issues_trees_path(request.query_parameters)
+         index_without_redmine_issues_tree
       end
     else
-      index_without_redmine_issues_tree
+      if Setting.plugin_redmine_issues_tree.with_indifferent_access[:default_redirect_to_issues_tree_view] == 'true' 
+        #tree_index
+        #redirect_with_params_issues_trees_path
+        redirect_to tree_index_issues_trees_path(request.query_parameters)
+      else
+        index_without_redmine_issues_tree
+      end
     end
   end
 


### PR DESCRIPTION
Just to clarify: the default tree view was only available on issues page of /project/xxx/.
So I've made some changes to enable it also on top /issues page.

#66 - Minor bugs in 3.4 