### PR TITLE
Some crude fixes for Redmine 4.0.0 with Rails 5 and Ruby 2.4

### DIFF
--- a/app/controllers/issues_trees_controller.rb
+++ b/app/controllers/issues_trees_controller.rb
@@ -51,7 +51,7 @@ class IssuesTreesController < ApplicationController
   # Retrieve a first level of a nested (children) issues
   def tree_children
     # merge for proper work of retrieve_query
-    params.merge!(params[:query_params])
+    params.permit!.merge!(params[:query_params])
 
     retrieve_query
 
@@ -65,7 +65,7 @@ class IssuesTreesController < ApplicationController
 
   # Redirect with proper params from serialized form
   def redirect_with_params
-    params_for_redirect = params.reject{|k, _| [:action, :controller, :utf8].include?(k.to_sym)}
+    params_for_redirect = params.reject{|k, _| [:action, :controller, :utf8].include?(k.to_sym)}.permit!
     if @project.present?
       render json: {redirect: tree_index_project_issues_trees_path(params_for_redirect)}
     else

--- a/lib/redmine_issues_tree/issues_controller_patch.rb
+++ b/lib/redmine_issues_tree/issues_controller_patch.rb
@@ -2,7 +2,8 @@ module RedmineIssuesTree::IssuesControllerPatch
   extend ActiveSupport::Concern
 
   included do
-    alias_method_chain :index, :redmine_issues_tree
+    alias_method :index_without_redmine_issues_tree, :index
+    alias_method :index, :index_with_redmine_issues_tree
   end
 
   def index_with_redmine_issues_tree


### PR DESCRIPTION
After updating the system, the plugin stopped to work due to changes in Ruby and Rails. In Rails 5 parameters need to be filtered. I now simply allow all, though that is likely not the best thing to do? But it works for me. And the other problem is that alias_method_chain is not supported anymore by recent Ruby versions. I replaced these now with alias_method, though a more appropriate approach may be to make use of the module prepend facility.

I have no idea, whether these changes are advisable, but I got the plugin running in Redmine 4.0 with this.