### PR TITLE
fix: check if referer is nil before parsing

### DIFF
--- a/lib/redmine_issues_tree/issues_controller_patch.rb
+++ b/lib/redmine_issues_tree/issues_controller_patch.rb
@@ -9,7 +9,8 @@ module RedmineIssuesTree
           if settings[:default_redirect_to_tree_view] == 'true'
             # @note: add additional parameter into all links on issues#index looks not so good as parsing a referer
             # @reason: we must prevent redirect to the tree_view if we do some actions on a plain view
-            if skip_issues_tree_redirect == 'true' || URI(request.referer).path == project_issues_path
+            if skip_issues_tree_redirect == 'true' ||
+              (request.referer && URI(request.referer).path == project_issues_path)
               super
             else
               redirect_to tree_index_project_issues_trees_path(request.query_parameters)


### PR DESCRIPTION
Adds check for referer presence before comparing paths. 

Should fix #110, credits to @LSA-ENZ for the proposed solution.