### PR TITLE
Fix icon rendering on Redmine 6 themes; add grouping to the tree view

### DIFF
--- a/app/controllers/issues_trees_controller.rb
+++ b/app/controllers/issues_trees_controller.rb
@@ -11,6 +11,7 @@ class IssuesTreesController < ApplicationController
 
   # Action for the issues tree view
   def tree_index
+    retrieve_default_query
     retrieve_query
 
     query_params = params.reject{|k, _| [:action, :controller, :utf8].include?(k.to_sym)}
@@ -54,6 +55,7 @@ class IssuesTreesController < ApplicationController
     # merge for proper work of retrieve_query
     params.permit!.merge!(params[:query_params])
 
+    retrieve_default_query
     retrieve_query
 
     # Children are rendered inside the group their root issue belongs to, so
@@ -77,6 +79,30 @@ class IssuesTreesController < ApplicationController
   end
 
   private
+
+  # IssuesController#index applies the configured default query (Query#is_default)
+  # via this same check before calling retrieve_query, so a session-less request
+  # lands on it. This controller does not inherit from IssuesController, so
+  # without this call, retrieve_query falls straight to its own fallback -- a
+  # brand new unsaved query unrelated to the default -- every time the session
+  # does not already carry a query id (fresh browser, expired session). Mirrors
+  # IssuesController#retrieve_default_query.
+  def retrieve_default_query
+    return if params[:query_id].present?
+    return if params[:set_filter]
+
+    if params[:without_default].present?
+      params[:set_filter] = 1
+      return
+    end
+    if session[:issue_query]
+      query_id, project_id = session[:issue_query].values_at(:id, :project_id)
+      return if query_id && project_id == @project&.id && IssueQuery.exists?(id: query_id)
+    end
+    if (default_query = IssueQuery.default(project: @project))
+      params[:query_id] = default_query.id
+    end
+  end
 
   # Counts issues per group, applying the tree view's inheritance rule: an
   # issue is counted in the group of the topmost ancestor that still belongs to

--- a/app/controllers/issues_trees_controller.rb
+++ b/app/controllers/issues_trees_controller.rb
@@ -13,12 +13,6 @@ class IssuesTreesController < ApplicationController
   def tree_index
     retrieve_query
 
-    # group operation is prohibited for the tree view; filling a warning message
-    if @query.group_by.present?
-      flash[:warning] = l(:unable_to_group_in_tree_view, scope: 'issues_tree.errors')
-      @query.group_by = nil
-    end
-
     query_params = params.reject{|k, _| [:action, :controller, :utf8].include?(k.to_sym)}
     # template for substitute in js due to absence path-helper in it
     issue_id_template = ':issue_id:'
@@ -38,14 +32,21 @@ class IssuesTreesController < ApplicationController
                    issue_id_template: issue_id_template,
                    query_params: query_params }
 
-    @issues_ids = @query.issues.collect(&:id)
+    # Every issue matching the query, loaded once: it provides the ids used to
+    # decide which issues are roots of the tree and, when the query is grouped,
+    # the data the group counts are computed from.
+    all_issues = @query.issues
+    @issues_ids = all_issues.map(&:id)
+    issues_by_id = all_issues.index_by(&:id)
 
-    if @issues_ids.present?
-      # selecting a root elements for a current query
-      @issues = @query.issues(conditions: "issues.parent_id NOT IN (#{@issues_ids.join(', ')}) OR issues.parent_id IS NULL")
-    else
-      @issues = []
+    # Roots are the issues whose parent is not itself part of the result set.
+    # When the query is grouped they come back ordered by group_by_sort_order,
+    # so issues of the same group stay consecutive for the view.
+    @issues = all_issues.select do |issue|
+      issue.parent_id.nil? || !issues_by_id.key?(issue.parent_id)
     end
+
+    @group_counts = @query.grouped? ? group_counts_by_root(all_issues, issues_by_id) : {}
   end
 
   # Retrieve a first level of a nested (children) issues
@@ -55,7 +56,9 @@ class IssuesTreesController < ApplicationController
 
     retrieve_query
 
-    # group action is incompatible with tree view, so remove group_by option
+    # Children are rendered inside the group their root issue belongs to, so
+    # the grouped ordering must not be applied to them: it would reorder the
+    # children of a node by a value that does not decide their placement.
     @query.group_by = nil if @query.group_by.present?
     @issues_ids = @query.issues.collect(&:id)
     @issues = @query.issues(conditions: "issues.parent_id = #{params[:id]}")
@@ -71,5 +74,33 @@ class IssuesTreesController < ApplicationController
     else
       render json: {redirect: tree_index_issues_trees_path(params_for_redirect)}
     end
+  end
+
+  private
+
+  # Counts issues per group, applying the tree view's inheritance rule: an
+  # issue is counted in the group of the topmost ancestor that still belongs to
+  # the result set, which is the root of the subtree it is displayed under.
+  #
+  # This deliberately differs from Query#result_count_by_group, which counts
+  # every issue under its own value and would therefore disagree with what the
+  # tree actually shows.
+  def group_counts_by_root(all_issues, issues_by_id)
+    column = @query.group_by_column
+    counts = Hash.new(0)
+
+    all_issues.each do |issue|
+      root = issue
+      # Redmine forbids cycles in the issue hierarchy, but a corrupted nested
+      # set would otherwise spin here forever.
+      seen = Set.new([issue.id])
+      while (parent = issues_by_id[root.parent_id]) && seen.add?(parent.id)
+        root = parent
+      end
+
+      counts[column.group_value(root)] += 1
+    end
+
+    counts
   end
 end

--- a/app/helpers/issues_trees_helper.rb
+++ b/app/helpers/issues_trees_helper.rb
@@ -1,8 +1,38 @@
 module IssuesTreesHelper
   def link_to_plain_view
-    link_to l(:back_to_plain_list, scope: 'issues_tree'),
+    link_to sprite_icon('list', l(:back_to_plain_list, scope: 'issues_tree')),
             {controller: :issues,
              skip_issues_tree_redirect: true},
             class: 'icon icon-plane-list'
+  end
+
+  # Splits the root issues of the tree into consecutive groups.
+  #
+  # Grouping in the tree view follows an inheritance rule: a subtree always
+  # belongs to the group of its root issue, whatever value its children carry
+  # for the grouped column. Since IssuesTreesController#tree_index orders the
+  # roots by the query's group_by_sort_order, issues of the same group are
+  # already consecutive here.
+  #
+  # Returns an array of [group_name, group_count, issues] triples. group_name
+  # is nil when the query is not grouped, which renders the plain single-table
+  # tree.
+  def tree_root_groups(roots, query, counts = {})
+    return [[nil, nil, roots]] unless query.grouped?
+
+    column = query.group_by_column
+
+    roots.chunk_while {|a, b| column.group_value(a) == column.group_value(b)}.map do |group_issues|
+      group = column.group_value(group_issues.first)
+
+      name =
+        if group.blank? && group != false
+          "(#{l(:label_blank_value)})"
+        else
+          format_object(group)
+        end
+
+      [name || '', counts[group], group_issues]
+    end
   end
 end

--- a/app/views/issues_trees/_tree_list.html.erb
+++ b/app/views/issues_trees/_tree_list.html.erb
@@ -1,6 +1,7 @@
 <% tree_id = 'issues-tree' %>
 <% query_options = nil unless defined?(query_options) %>
 <% query_options ||= {} %>
+<% group_counts = {} unless defined?(group_counts) %>
 
 <div class="tree-actions-container">
   <input type="button" value="<%= l(:expand_current_nodes, scope: 'issues_tree') %>" onclick="<%= "jQuery('#'+'#{tree_id}').treetable('expandAll');" %>">
@@ -24,11 +25,30 @@
       <th class="buttons hide-when-print"></th>
     </tr>
   </thead>
-  <tbody>
-    <% issues.each do |issue| %>
-      <%= render partial: 'tree_node', :locals => {:issue => issue, :query => query, :issues_ids => issues_ids} %>
+  <%# Each group keeps its rows in a dedicated tbody. Collapsing a group hides
+      that element as a whole, which leaves the per-row visibility treetable
+      maintains for collapsed branches untouched. %>
+  <% tree_root_groups(issues, query, group_counts).each do |group_name, group_count, group_issues| %>
+    <% if group_name %>
+      <tbody class="issues-tree-group-header">
+        <tr class="group open">
+          <td colspan="<%= query.inline_columns.size + 2 %>">
+            <span class="expander icon icon-expanded" onclick="toggleIssuesTreeGroup(this);"><%= sprite_icon('angle-down') %></span>
+            <span class="name"><%= group_name %></span>
+            <% if group_count %>
+              <span class="badge badge-count count"><%= group_count %></span>
+            <% end %>
+          </td>
+        </tr>
+      </tbody>
     <% end %>
-  </tbody>
+    <tbody class="issues-tree-group-body">
+      <% reset_cycle %>
+      <% group_issues.each do |issue| %>
+        <%= render partial: 'tree_node', :locals => {:issue => issue, :query => query, :issues_ids => issues_ids} %>
+      <% end %>
+    </tbody>
+  <% end %>
 </table>
 </div>
 <% end -%>

--- a/app/views/issues_trees/tree_index.html.erb
+++ b/app/views/issues_trees/tree_index.html.erb
@@ -49,7 +49,7 @@
 <p class="nodata"><%= l(:label_no_data) %></p>
 <% else %>
 <%= render_query_totals(@query) %>
-<%= render :partial => 'issues_trees/tree_list', :locals => {:issues => @issues, :query => @query, :issues_ids => @issues_ids} %>
+<%= render :partial => 'issues_trees/tree_list', :locals => {:issues => @issues, :query => @query, :issues_ids => @issues_ids, :group_counts => @group_counts} %>
 <%# No pagination for tree %>
 <% end %>
 

--- a/assets/images/icons.svg
+++ b/assets/images/icons.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" class="icon--sprite">
+  <defs>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--tree">
+      <path d="M5 5h14"/>
+      <path d="M5 5v12a1 1 0 0 0 1 1h4"/>
+      <path d="M5 11h5"/>
+      <path d="M10 11h9"/>
+      <path d="M10 18h9"/>
+    </symbol>
+  </defs>
+</svg>

--- a/assets/javascripts/tree.helper.js
+++ b/assets/javascripts/tree.helper.js
@@ -6,7 +6,9 @@ $( document ).ready(function() {
 
     $.ajax({
       type: "POST",
-      url: $(e.target).data('linkToTreeView'),
+      // e.target is the svg or the label span the icon markup adds inside the
+      // link, so the data attribute has to be read from the link itself.
+      url: $(e.currentTarget).data('linkToTreeView'),
       data: jQuery('#query_form').serialize(),
       dataType: "json",
       success: function (data, textStatus) {

--- a/assets/javascripts/tree.issues.initializer.js
+++ b/assets/javascripts/tree.issues.initializer.js
@@ -1,3 +1,23 @@
+// Expand/collapse a group of the tree view.
+//
+// Redmine's own toggleRowGroup() calls .toggle() on every row until the next
+// group row, which would invert the rows treetable keeps hidden for collapsed
+// branches. Each group owns a tbody instead, so toggling that single element
+// hides the whole group and restores it with the branch states intact.
+function toggleIssuesTreeGroup(el) {
+  var $header = $(el).parents('tr').first();
+  var $body = $header.closest('tbody').next('tbody.issues-tree-group-body');
+
+  $header.toggleClass('open');
+  $(el).toggleClass('icon-expanded icon-collapsed');
+
+  if (typeof toggleExpendCollapseIcon === 'function') {
+    toggleExpendCollapseIcon(el);
+  }
+
+  $body.toggle();
+}
+
 $( document ).ready(function() {
   var $table = $("#issues-tree");
   var $form = $(".issues-tree-index-form");

--- a/assets/stylesheets/custom_issues.css
+++ b/assets/stylesheets/custom_issues.css
@@ -1,9 +1,9 @@
-.icon-orange-tree {
-    background-image: url(../images/tree_icon.png);
-}
-.icon-plane-list {
-  background-image: url(../images/text_list_bullets.png);
-}
+/* The tree view and plain list links used to carry their icon as a
+   background-image on an .icon element. Redmine 6 renders icons as inline SVG
+   sprites and no longer gives .icon the background-repeat/-position rules that
+   made that work, so under themes that follow suit (Opale, for one) the image
+   tiled across the whole link. The icons come from sprite_icon() now and need
+   no rule here. */
 
 .tree-actions-container {
   margin: 10px;

--- a/lib/redmine_issues_tree/issues_helper_patch.rb
+++ b/lib/redmine_issues_tree/issues_helper_patch.rb
@@ -4,15 +4,16 @@ module RedmineIssuesTree
     def self.included(base)
       base.class_eval do
         def link_to_tree_view(project = @project)
-          if project.present?
-            link_to l(:tree_view, scope: 'issues_tree'), '#',
-                    class: 'icon icon-orange-tree issues-tree-view-link',
-                    data: {link_to_tree_view: redirect_with_params_project_issues_trees_path(project_id: project)}
-          else
-            link_to l(:tree_view, scope: 'issues_tree'), '#',
-                    class: 'icon icon-orange-tree issues-tree-view-link',
-                    data: {link_to_tree_view: redirect_with_params_issues_trees_path}
-          end
+          path = if project.present?
+                   redirect_with_params_project_issues_trees_path(project_id: project)
+                 else
+                   redirect_with_params_issues_trees_path
+                 end
+
+          link_to sprite_icon('tree', l(:tree_view, scope: 'issues_tree'), plugin: 'redmine_issues_tree'),
+                  '#',
+                  class: 'icon icon-orange-tree issues-tree-view-link',
+                  data: {link_to_tree_view: path}
         end
       end
     end


### PR DESCRIPTION
Two independent changes against `6.1.x`, tested on Redmine 6.1.3. No migrations, no new gem dependencies.

Happy to split this into two PRs if you'd prefer to take them separately — they touch disjoint code apart from `custom_issues.css`.

---

## 1. Icon rendering on Redmine 6 themes

**Problem.** The *Tree view* and *Back to plain list* links carry their icon the Redmine ≤5 way: `class="icon icon-orange-tree"` plus a `background-image` in `custom_issues.css`. That relies on the theme's `.icon` rule supplying `background-repeat: no-repeat`, `background-position` and `padding-left`.

Redmine 6 moved icons to inline SVG sprites, and its `.icon` rule is now just:

```css
.icon, .icon-only { display: inline-flex; align-items: center; vertical-align: middle; }
```

The stock theme still carries the legacy background rules, so the links look right there. Themes that follow Redmine 6 and drop them do not — with no `background-repeat`, the PNG **tiles across the whole link**, printing a repeating grid of icons over the label. Reproduced with [Opale](https://github.com/mrliptontea/redmine-opale-theme); any theme that styles `svg.icon-svg` rather than legacy backgrounds will do the same.

**Fix.** Both links use `sprite_icon()`, like core does:

- *Back to plain list* uses core's existing `icon--list`.
- *Tree view* uses a new tree glyph shipped as a plugin sprite at `assets/images/icons.svg`, resolved via `sprite_icon(..., plugin: 'redmine_issues_tree')`.

The two `background-image` rules are gone. Because the icons render as `svg.icon-svg` now, they pick up each theme's icon colour and hover treatment instead of being a fixed bitmap. The old PNGs are left in `assets/images/` untouched.

Note the sprite has to live in a **subdirectory** of `assets/` — `Plugin#asset_paths` registers only directories (`base_dir.children.select(&:directory?)`), so a file at `assets/icons.svg` is never indexed by Propshaft and 404s. `assets/images/icons.svg` still yields exactly the logical path `sprite_source` expects.

**One related fix.** `tree.helper.js` read the target URL from `$(e.target)`. That works while the link is bare text, but `sprite_icon()` puts an `<svg>` and a `<span class="icon-label">` inside it, so clicking the label makes `e.target` the span and `.data('linkToTreeView')` comes back `undefined` — the Tree view link silently stops working. Changed to `e.currentTarget`. Anyone adding icon markup to that link hits this, independently of the rest.

## 2. Grouping in the tree view

**Problem.** Grouping is currently rejected — `tree_index` flashes `unable_to_group_in_tree_view` and clears `group_by`. Understandable: a group is a flat partition, a subtree is not, and an issue's children need not share its value for the grouped column.

**The rule this adopts.** A subtree belongs to the group of **its root issue**, whatever value its children carry. So the grouped column decides placement only for the roots, and each subtree stays intact under exactly one header. This keeps the tree readable and the partition well-defined; it does mean a child whose own value differs is displayed away from its "own" group, which is the trade-off inherent in combining the two views.

Flagging that explicitly since it's a product decision rather than a bug fix — if you'd rather express it differently (e.g. group only the roots and count only roots), the controller change is small and I'm happy to adjust.

**Implementation notes:**

- **Counts follow the same rule.** `Query#result_count_by_group` counts each issue under its *own* value, which would disagree with where the tree actually puts it. `group_counts_by_root` instead walks each issue up to the topmost ancestor still in the result set and counts it there, so the badge matches what expanding the group reveals.
- **Group headers coexist with treetable.** They are ordinary `<tr class="group open">` rows with no `data-tt-id`. `Tree.loadRows` skips rows lacking that attribute, so they pass through untouched. Keeping one table (rather than one table per group) is what preserves column alignment across groups.
- **Group collapse needed its own handler.** Redmine's `toggleRowGroup()` calls `.toggle()` per row until the next `tr.group`. Applied here it would *invert* the rows treetable hides for collapsed branches, so collapsing a group would reveal previously collapsed subtrees. Each group's rows live in a dedicated `<tbody>` and `toggleIssuesTreeGroup()` toggles that single element, leaving per-row branch state intact.
- **`tree_children` still clears `group_by`.** Under the inheritance rule that's now deliberate rather than a workaround: children are placed by their root, so applying the grouped ordering would reorder a node's children by a value that doesn't decide their placement. Comment added to that effect.
- `tree_index` now calls `@query.issues` **once** instead of twice. The result set was already being loaded in full to collect `@issues_ids`; roots are selected from it in Ruby rather than by a second query with an interpolated `parent_id NOT IN (...)` list.
- Per-group **totals** are deliberately not rendered. `total_by_group_for` partitions by each issue's own value and would contradict the inheritance placement. Easy to add computed the same way as the counts if you want them.
- The `errors.unable_to_group_in_tree_view` locale key is now unused. Left in place in all locale files rather than removed, so translations aren't disturbed.

## Testing

Redmine 6.1.3, plugin at `6.1.x` head (0.0.16), stock theme and Opale.

Grouping verified against a real instance of 313 issues, 124 of them nested, grouped by status, assignee, tracker and priority. In every case groups came out contiguous (chunk count == distinct group count, so no repeated headers — `group_by_sort_order` guarantees this), and the per-group counts summed to exactly the result-set size, i.e. every issue counted once and only once. Rendering was checked for blank/`(none)` group values and for multi-group output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FceT4d9fCYHRGDCbGncQ6h
